### PR TITLE
Small bug fixes

### DIFF
--- a/src/learnrxjava/ComposableList.java
+++ b/src/learnrxjava/ComposableList.java
@@ -749,7 +749,7 @@ public class ComposableList<T> extends ArrayList<T> {
 
      This is a variation of the problem we solved earlier, where we retrieved the url of the boxart with a width of 150px. This time we'll use reduce() instead of filter() to retrieve the smallest box art in the boxarts list.
      */
-    public JSON exercise19() {
+    public ComposableList<JSON> exercise19() {
         ComposableList<MovieList> movieLists = ComposableList.of(
                 new MovieList(
                         "New Releases",

--- a/src/learnrxjava/ComposableList.java
+++ b/src/learnrxjava/ComposableList.java
@@ -424,9 +424,9 @@ public class ComposableList<T> extends ArrayList<T> {
      Unfortunately List doesn't have a concatMap method and there's no way for us to add one. However we _can_ define a static method concatMap. The concatMap method accepts a ComposableList<T> , a function that accepts a single value and returns a collection (Function<T, ComposableList<R>> ), and returns a flat list of the results (ComposableList<R> ).
      */
 
-    public static <T, R> ComposableList<R> concatMap(ComposableList<T> that, Function<T, List<R>> projectionFunctionThatReturnsList) {
+    public <R> ComposableList<R> concatMap(Function<T, ComposableList<R>> projectionFunctionThatReturnsList) {
         ComposableList<R> results = new ComposableList<R>();
-        for (T itemInList : that) {
+        for (T itemInList : this) {
             // ------------ INSERT CODE HERE! ----------------------------
             // Apply the projection function to each item in the list.
             // This will create _another_ list. Then loop through each
@@ -618,7 +618,7 @@ public class ComposableList<T> extends ArrayList<T> {
             // the previous computation back into the combiner function until
             // we've exhausted the entire list and are left with only one function.
             while (counter < this.size()) {
-                accumulatedValue = combiner.apply(accumulatedValue, this.get(1));
+                accumulatedValue = combiner.apply(accumulatedValue, this.get(counter));
                 counter++;
             }
 
@@ -643,7 +643,7 @@ public class ComposableList<T> extends ArrayList<T> {
             // the previous computation back into the combiner function until
             // we've exhausted the entire list and are left with only one function.
             while (counter < this.size()) {
-                accumulatedValue = combiner.apply(accumulatedValue, this.get(0));
+                accumulatedValue = combiner.apply(accumulatedValue, this.get(counter));
                 counter++;
             }
 


### PR DESCRIPTION
The implementations of reduce were fixed. They used to iterate over the same element in the list, now it correctly iterates over every element in the list. concatMap was made into an instance method. Changed the return type of exercise19 to be consistent with the other exercises. 
